### PR TITLE
Add my plugins CCbooks

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -129,5 +129,9 @@
 	{
   		"name": "Mycroft Cat",
   		"url": "https://github.com/pazoff/Mycroft-Cat"
+	},
+	{
+		"name": "CCbooks",
+  		"url": "https://github.com/rinaldilab/CCbooks-Books-Finder"
 	}
 ]


### PR DESCRIPTION
CCBooks is a plugin developed for Cheshire Cat AI designed to simplify the search for book information through the exclusive use of the ISBN.
This tool integrates seamlessly into the Cheshire Cat environment offering users a quick and efficient way to access vital details about books .
With CCBooks simply enter the ISBN number of the desired book and let the plugin take care of the rest.
Using the Google API crucial details such as author title publisher publication datedescription small image and many others are retrieved.
This information is presented in a clear and organized manner allowing users to quickly get a complete overview of the book they are interested in and can interact with specific questions.