### PR TITLE
MistralAI support,Ollama runtime Fix and jina embedder support

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -162,5 +162,10 @@
 	{
 		"name": "Ollama-Fix",
     		"url": "https://github.com/valentimarco/Ollama-Fix"
+	},
+	{
+		"name": "Jina-Integration",
+    		"url": "https://github.com/valentimarco/Jina-Integration"
 	}
+	
 ]

--- a/plugins.json
+++ b/plugins.json
@@ -154,5 +154,13 @@
   	{
 		"name": "Related Questions",
     		"url": "https://github.com/pazoff/Related-Questions-Plugin"
+	},
+	{
+		"name": "MistralAI-Integration",
+    		"url": "https://github.com/valentimarco/MistralAI-Integration"
+	},
+	{
+		"name": "Ollama-Fix",
+    		"url": "https://github.com/valentimarco/Ollama-Fix"
 	}
 ]


### PR DESCRIPTION
Adding new 3 plugins:
- MistralAI, Adding support of the SaaS service they offer. Similar price of OpenAI
- OllamaFix, A Runtime fix for ollama class to be able to use the automatic stop string list from the runner
- Jina Embedders, Requested by @nickprock 