### PR TITLE
add PDF to Audio Cat plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -174,6 +174,10 @@
 	{
 		"name": "FireworksAI-Integration",
     		"url": "https://github.com/valentimarco/Fireworks-integration"
+	},
+	{
+		"name": "PDF to Audio Cat",
+    		"url": "https://github.com/pazoff/PDF-to-Audio-Plugin"
 	}
 	
 ]


### PR DESCRIPTION
https://github.com/pazoff/PDF-to-Audio-Plugin

PDF to Audio Cat plugin for your [Cheshire cat](https://github.com/cheshire-cat-ai/core) involves converting text content in PDF files into audio (MP3,OGG,WAV), enabling you to listen to the document instead of reading it.