### PR TITLE
add FinCat - ETF checker plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -186,6 +186,10 @@
 	{
 		"name": "Bing Image Creator Cat",
     		"url": "https://github.com/pazoff/Bing-Image-Creator-Cat"
+	},
+	{
+		"name": "FinCat - ETF Checker",
+    		"url": "https://github.com/theperu/FinCat-ETF-Checker"
 	}
 	
 ]


### PR DESCRIPTION
Added [FinCat - ETF Checker](https://github.com/theperu/FinCat-ETF-Checker) a plugin that lets you search information about ETFs (Exchange Traded Fund). You just need to provide the cat with an ISIN or a Ticker and it will search from the ones that are available on [JustETF](https://github.com/theperu/FinCat-ETF-Checker/blob/main/justetf.com). You can also ask it to look for similar ones based on the same index.