### PR TITLE
add Wolfram Alpha Cat plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -190,6 +190,10 @@
 	{
 		"name": "FinCat - ETF Checker",
     		"url": "https://github.com/theperu/FinCat-ETF-Checker"
+	},
+	{
+		"name": "Wolfram Alpha Cat",
+    		"url": "https://github.com/pazoff/wolfram-alpha-cat"
 	}
 	
 ]


### PR DESCRIPTION
https://github.com/pazoff/wolfram-alpha-cat

Connects the Cheshire Cat to the Wolfram Alpha using its free API.