### PR TITLE
Add the image background remover plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -262,5 +262,9 @@
   {
     "name": "HA Agent",
     "url": "https://github.com/lucagobbi/ha_agent"
+  },
+  {
+    "name": "Purrfectly Clear Background",
+    "url": "https://github.com/enricollen/Purrfectly_Clear_Background"
   }
 ]


### PR DESCRIPTION
Purrfectly Clear Background is a simple plugin that lets you remove the background from an image you upload in chat