### PR TITLE
Add Youtube 2 text plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -294,5 +294,9 @@
   {
     "name": "Dynamic-Language",
     "url": "https://github.com/mimir-chatbot/Dynamic-Language"
+  },
+  {
+    "name": "Youtube 2 Text",
+    "url": "https://github.com/rafleze/youtube2text"
   }
 ]


### PR DESCRIPTION
Youtube 2 Text is a plugin that automatically transcribes the content of YouTube videos. It operates simply put a link to the video and the desired language code into the [Cheshire Cat AI](https://github.com/cheshire-cat-ai) conversational form.