### PR TITLE
Add CatLendar plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -306,5 +306,9 @@
   {
     "name": "TTS powered by OpenAI",
     "url": "https://github.com/Pingdred/openai-tts"
+  },
+  {
+    "name": "CatLendar",
+    "url": "https://github.com/The-Golden-At-SRL/CatLendar"
   }
 ]


### PR DESCRIPTION
This is a plugin that let your customers book an appointment directly in the chat!
This plugin is thought as an add-on for a B2C chatbot, for example it can be used in a chatbot on a website of accountants to book consultancies. An interesting feature is that it extracts the context of the chat previous the booking phase and give the booking a title (in the plugin called context).