### PR TITLE
Added CATalogator plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -314,5 +314,9 @@
   {
     "name": "Semantic Chunking",
     "url": "https://github.com/nickprock/ccat_semantic_chunking"
+  },
+  {
+    "name": "CATalogator",
+    "url": "https://github.com/Fede91/catalogator"
   }
 ]


### PR DESCRIPTION
CATalogator is a plugin for Cheshire-Cat that allows users to assign metadata to documents during upload and apply filters to the declarative memory to focus responses on specific documents.

Rif: https://github.com/cheshire-cat-ai/core/issues/812