### PR TITLE
Add My Cat Data Backup plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -386,5 +386,9 @@
   {
     "name": "Haloperidol - No hallucinations",
     "url": "https://github.com/pieroit/haloperidol"
+  },
+  {
+    "name": "Cat Data Backup",
+    "url": "https://github.com/ap-70/cat_data_backup"
   }
 ]


### PR DESCRIPTION
This is a plugin that when the Cat starts saves a zipped copy of the 'data' folder in './cat/static/backup/' that can be recovered if necessary. To force another save just write:: ...save the cat's data.