### PR TITLE
Add Ccat Groups plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -398,5 +398,9 @@
   {
     "name": "Catcloak",
     "url": "https://github.com/lucagobbi/catcloak"
+  },
+  {
+    "name": "Ccat Groups",
+    "url": "https://github.com/Tiestaa/ccat_groups"
   }
 ]


### PR DESCRIPTION
Create and handle groups using this plugin. CCat Groups enables the segmentation of declarative memory based on group names. The group admin can add users and upload documents to Rabbit Hole. Every group member will retrieve these documents to augment the prompt.

example:
1. User `admin` creates a group called `test` and switches the current group to test by using  `@p test`
2. `admin` uploads documents to Rabbit Hole.
3. `admin` adds the user `pippo` to `test`
4. `pippo` can use command `@l` to get the groups' list, that includes the group `test`
5. `pippo` can switch his active group to `test` by using command: `@p test`
6. ⁠When ⁠ `pippo` ⁠ makes a query about something, the retrieval phase includes all the documents previously uploaded by the admin belonging to the group `test`