### PR TITLE
add Cat Overflow plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -410,5 +410,9 @@
   {
     "name": "Catnesina",
     "url": "https://github.com/redringofdeath/catnesina"
+  },
+  {
+    "name": "Cat Overflow",
+    "url": "https://github.com/scicco/cat-overflow"
   }
 ]


### PR DESCRIPTION
# Cat Overflow

## Let the Cat become your coding assistant by learning everything about your favourite libraries! 

This plugin will help Cheshire cat users by assisting them in ingesting repository source code, documentation sites and questions for a specific library

In the current release, you can:

- import a GitHub repository with or without a GitHub API token (`@getcode library_name`)
- search and ingest a page from a site (useful if you want to import existing documentation (`@getcodedoc URL`)

planned features:

- search with Google for additional pages
- search in StackOverflow for a topic