### PR TITLE
my plugin to leverage Scryfall public API the get info about MTG cards

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -430,5 +430,9 @@
   {
     "name": "Folder Ingestor",
     "url": "https://github.com/davidebizzocchi/folder-ingestor"
+  },
+  {
+    "name": "Magic Arbiter AI",
+    "url": "https://github.com/vancif/cat-magic-arbiter"
   }
 ]


### PR DESCRIPTION
This plugin features a tool and a hook.
The tool simply use 2 APIs the get detailed info about a card and the hook set a proper prompt to the chain.