### PR TITLE
Add Cat File Generator plugin to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -434,5 +434,9 @@
   {
     "name": "Magic Arbiter AI",
     "url": "https://github.com/vancif/cat-magic-arbiter"
+  },
+  {
+    "name": "Cat File Generator",
+    "url": "https://github.com/davidegavio/cat-file-generator"
   }
 ]


### PR DESCRIPTION
Plugin that allow the cat to generate different file types: at the moment, txt and pdf files are supported