### PR TITLE
Header and Footer CATter plugin to plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -442,5 +442,9 @@
   {
     "name": "SuperCatForm",
     "url": "https://github.com/lucagobbi/super-cat-form"
+  },
+  {
+  "name": "Header and Footer CATter",
+  "url": "https://github.com/mallibus/header_footer_cat_plugin"
   }
 ]


### PR DESCRIPTION
This plugin helps in removing useless and annoying header and footer lines in the documents before the chunking happens. The header and footer are inferred by looking for the same lines in the top of bottom of multiple pages.  The comparison is done with fuzzy similarity to avoid small differences as page numbers to ruin the process.