### PR TITLE
MultiCat

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -450,5 +450,9 @@
   {
     "name": "Cat on a Petals",
     "url": "https://github.com/scicco/cat-on-a-petals"
+  },
+  {
+    "name": "MultiCat",
+    "url": "https://github.com/davidebizzocchi/multicat"
   }
 ]


### PR DESCRIPTION
This plugin allows you to use the reference Django project to use CheshireCat in multichat.