### PR TITLE
Update plugins.json No Think Plugin for The Cat (Qwen3)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -494,5 +494,9 @@
   {
     "name": "Telegram Message Sender",
     "url": "https://github.com/zhangmjcn/telegram-message-sender-for-cheshire-cat"
+  },
+  {
+    "name": "No Think Plugin for The Cat (Qwen3)",
+    "url": "https://github.com/canapaio/q3_no_think"
   }
 ]


### PR DESCRIPTION
No Think Plugin for The Cat (Qwen3)
This plugin helps:

    Prepend /no_think to incoming messages (Qwen3)
    Strip /no_think before storing in memory or recalling (Qwen3)
    Remove internal thinking blocks <think> Thinking: ... Result (like Thinking: ... Result:) from the final output sent to the user (all R models)