### PR TITLE
Langfuse Connector plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -498,5 +498,9 @@
   {
     "name": "No Think Plugin for The Cat (Qwen3)",
     "url": "https://github.com/canapaio/q3_no_think"
+  },
+  {
+    "name": "Langfuse Connector",
+    "url": "https://github.com/net7/langfuse-connector"
   }
 ]


### PR DESCRIPTION
This plugin can establish a connection to Langfuse (self-hosted or cloud) to enable real-time tracing and observability