### PR TITLE
Add Declarative-memory-api-plugin to registry

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -514,5 +514,9 @@
   {
     "name": "Vision PDF parser",
     "url": "https://github.com/matteo-brandolino/ccat_vision_pdf_parser"
+  },
+  {
+    "name": "Declarative Memory API Plugin",
+    "url": "https://github.com/mc9625/mem_retriever"
   }
 ]


### PR DESCRIPTION
Hi folks, this is my first official submission, so be patient!
This is a plugin for Cheshire Cat AI that provides direct access to declarative memory without LLM overhead.
It could be used to help integration with third parties solutions that may be difficult to integrate natively within the CAT.
For instance it could be used to retrieve declarative memory to be used as context for external LLMs or closed systems.

The plugin includes a `plugin.json` and a `README.md` in its repository.

https://github.com/mc9625/mem_retriever

Here is the .zip release: https://github.com/mc9625/mem_retriever/archive/refs/tags/v0.1.0.zip

Thank you for your patience, your support and your great job!