### PR TITLE
Add OpenAI API Bridge

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -518,5 +518,9 @@
   {
     "name": "Declarative Memory API Plugin",
     "url": "https://github.com/mc9625/mem_retriever"
+  },
+  {
+    "name": "OpenAI API Bridge",
+    "url": "https://github.com/mc9625/cat_openai_api"
   }
 ]


### PR DESCRIPTION
Plugin that exposes OpenAI-compatible API endpoints for any application that needs to interact with Cheshire Cat using standard OpenAI API formats. Includes conversation memory, rate limiting, and comprehensive metrics.

Here is the link to the repo: https://github.com/mc9625/cat_openai_api