### PR TITLE
Add Claw the Ollama plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -542,5 +542,9 @@
   {
     "name": "ReAct Agent",
     "url": "https://github.com/Pingdred/ccat_af_react"
+  },
+  {
+    "name": "Claw the Ollama",
+    "url": "https://github.com/davidemodolo/claw-the-ollama"
   }
 ]


### PR DESCRIPTION
I added my plugin "Claw the Ollama" to the list.

### What does it resolve?

If the user set Ollama as LLM provider and selected a model that is not downloaded on the machine, they get this error:

<img width="521" height="228" alt="image" src="https://github.com/user-attachments/assets/af594b3a-d627-46f8-aa08-1c0864e34d91" />

### Solution

- it hooks to "before_cat_reads_message"
- checks if the user set Ollama as LLM provider using  `crud.get_settings()`
- if so, checks if the selected model is available locally using `requests.get(f"{base_url}/api/tags")`, with `base_url` from the LLM provider settings
- if it isn't available, it pulls it using `requests.Response = requests.post(f"{base_url}/api/pull", json={"name": model}, stream=True)`
- during the download, the user is updated on the process with a websocket message every 5 seconds, similarly to the rabbit hole
- after the download, the cat starts responding immediately.

It does not require any additional library.

<img width="872" height="162" alt="Screenshot from 2025-08-19 18-36-31" src="https://github.com/user-attachments/assets/bf23e057-aa29-46c4-b9f3-8cbc0cf48a63" />
<img width="872" height="162" alt="Screenshot from 2025-08-19 18-36-39" src="https://github.com/user-attachments/assets/b7024197-b215-4cea-bac4-7bd5f76826df" />
<img width="872" height="162" alt="Screenshot from 2025-08-19 18-37-49" src="https://github.com/user-attachments/assets/e2986666-13d1-4d3d-b4ea-effb15f13cc5" />
