### PR TITLE
add chat analytics plugin for prometheus

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -582,6 +582,9 @@
   {
     "name": "Temporary Chat Authentication",
     "url": "https://github.com/opencity-labs/ccat_temporary_chat_authentication"
+  },{
+    "name": "Chat Analytics",
+    "url": "https://github.com/opencity-labs/ccat_chat_analytics"
   },
   {
     "name": "Web UI for Cat version 2",


### PR DESCRIPTION
Added the plugin [Chat Analytics](https://github.com/opencity-labs/ccat_chat_analytics).

It exposes the `/custom/metrics` endpoint to track the usage of the Cat with Prometheus, tracking:
- average number of messages per chat
- the max number of messages that has been sent in a chat
- number of chats opened
- frequency of declarative memory points retrieved (the number of times each points is retrieved)
- sentiment of the user messages using SpaCy